### PR TITLE
Correction du nom de fichier pour le style de l'éditeur wysiwyg

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -39,7 +39,7 @@ register_nav_menus( array(
  *	This theme supports editor styles
  */
 
-add_editor_style("/css/layout-style.css");
+add_editor_style("/css/editor-style.css");
 
 
 


### PR DESCRIPTION
le fichier layout-style référé par la fonction n'existe pas alors que le fichier existant editor-style n'est référé nulle part.

rtl-editor-style.css n'est également référé nulle part, mais je laisse le choix de l'implémenter dans functions.php ou de le supprimer.
